### PR TITLE
Fixed missing forwards that are used by rostful

### DIFF
--- a/pyros_interfaces_ros/api/roslib_safe.py
+++ b/pyros_interfaces_ros/api/roslib_safe.py
@@ -9,3 +9,6 @@ import roslib
 # We wrap rospy function into safeguards for socket error
 # since the master seems to be quite sensitive to Network health.
 # TODO : refine which ones need which exception handling...
+
+def load_manifest(package_name):
+    roslib.load_manifest(package_name)

--- a/pyros_interfaces_ros/api/rospy_safe.py
+++ b/pyros_interfaces_ros/api/rospy_safe.py
@@ -189,6 +189,7 @@ Subscriber = rospy.Subscriber
 Publisher = rospy.Publisher
 Service = rospy.Service
 ServiceProxy = rospy.ServiceProxy
+ServiceException = rospy.ServiceException
 
 rostime = rospy.rostime
 

--- a/pyros_interfaces_ros/message_conversion.py
+++ b/pyros_interfaces_ros/message_conversion.py
@@ -397,7 +397,7 @@ def _load_class(modname, subname, classname):
 
     try:
         # roslib maintains a cache of loaded manifests, so no need to duplicate
-        roslib.launcher.load_manifest(modname)
+        roslib.load_manifest(modname)
     except Exception as exc:
         raise InvalidPackageException(modname, exc)
 


### PR DESCRIPTION
I stumbled into these issues with a REST/ROS Service, which had complex (ros message type) arrays in its service definition.